### PR TITLE
support s3 prefixes, add additional logging

### DIFF
--- a/Classes/BackupDatabase.php
+++ b/Classes/BackupDatabase.php
@@ -53,6 +53,7 @@ class BackupDatabase
      */
     public function backup()
     {
+        DUP_Logs::log("Backup Up Database");
         switch ($this->mode) {
             case 'MODE_PWAPI':
                 DUP_Logs::log("- Backup using standard mode");
@@ -91,7 +92,7 @@ class BackupDatabase
         else if($this->mode === 'MODE_NATIVE') {
             $return = null;
             $output = array();
-			
+
 			if($this->OS === 'UNIX') {
 				exec('zip '. $zipfile . ' '. $sqlfile, $output, $return);
 				unlink($sqlfile);
@@ -129,7 +130,7 @@ class BackupDatabase
         $backup->setDatabase($this->database);
         $backup->setDatabaseConfig(wire('config'));
         $sqlfile = $backup->backup($this->options);
-        
+
         return $sqlfile;
     }
 
@@ -149,7 +150,7 @@ class BackupDatabase
                 // not supported platform
                 return false;
         }
-        
+
         return false;
     }
 
@@ -196,7 +197,7 @@ class BackupDatabase
         set MYSQLUSER='. wire('config')->dbUser .'
         set MYSQLPASS='. wire('config')->dbPass .'
         "mysqldump.exe" -u%MYSQLUSER% -p%MYSQLPASS% --single-transaction --skip-lock-tables --routines --triggers %MYSQLDATABASE% > '. $cachePath . $this->options['backup']['filename'];
-        
+
         file_put_contents($cachePath . 'duplicator.bat', $data);
 
         $return = null;

--- a/Duplicator.module
+++ b/Duplicator.module
@@ -188,7 +188,8 @@ class Duplicator extends WireData implements Module, ConfigurableModule
             'awsAccessKey'   => '',
             'awsSecretKey'   => '',
             'awsBucketName'  => '',
-            'awsRegion'      => ''
+            'awsSubDir'      => '',
+            'awsRegion'      => '',
         );
     }
 
@@ -682,7 +683,7 @@ class Duplicator extends WireData implements Module, ConfigurableModule
                         }
                     }
                     if (!$bucketExist) $amazonaws->createBucket($this->awsBucketName);
-                    $amazonaws->upload($package['zipfile'], $packageName);
+                    $amazonaws->upload($package['zipfile'], $packageName, $this->awsSubDir);
                     //if($url === null) throw new AmazonS3ClientException("AmazonS3: An error occured while uploading package <{$packageName}>");
                     $amazonaws->deleteOldBackups($this->maxPackages, $this->deadline);
                 } catch(AmazonS3ClientException $ex) {
@@ -1560,7 +1561,16 @@ class Duplicator extends WireData implements Module, ConfigurableModule
         $field->description = __("The bucket where the packages will be stored.");
         $field->notes = __("The bucket will be created automatically if not found.");
         $field->value = $data['awsBucketName'];
-        $field->columnWidth = 70;
+        $field->columnWidth = 40;
+        $fsaws->append($field);
+
+        $field = $modules->get('InputfieldText');
+        $field->attr('name', 'awsSubDir');
+        $field->label = __("Bucket Sub Directory");
+        $field->description = __("The sub path where the packages will be stored.");
+        // $field->notes = __("The bucket will be created automatically if not found.");
+        $field->value = $data['awsSubDir'];
+        $field->columnWidth = 30;
         $fsaws->append($field);
 
         // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region


### PR DESCRIPTION
This PR adds an additional config field that allows you to set the prefix / sub directory of an S3 object.

This allows you to have a single bucket for example named "my-lovely-backups" and within that have subfields for each site you are backing up.
You can then have: 
`my-lovely-backups/siteA/backup1.package.zip`  
`my-lovely-backups/siteA/backup2.package.zip`  
`my-lovely-backups/siteB/backup1.package.zip`  
`my-lovely-backups/siteB/backup2.package.zip`  
etc etc.

This PR also adds some additional logging in areas I found useful when making these changes. 
