### PR TITLE
Fixed deprecated message

### DIFF
--- a/Deploy/installer.php
+++ b/Deploy/installer.php
@@ -1640,7 +1640,7 @@ class WireDatabaseBackup {
      * @return bool
      *
      */
-    protected function backupEndFile($file, array $summary = array(), array $options) {
+    protected function backupEndFile($file, array $summary = array(), array $options = array()) {
         $fp = is_resource($file) ? $file : fopen($file, 'a+');
 
         if(!$fp) {


### PR DESCRIPTION
Fixed deprecated message for PHP 7.4 and newer: "Required parameter $options follows optional parameter $summary"