### PR TITLE
Fixed deprecated message for usort

### DIFF
--- a/ProcessDuplicator.module
+++ b/ProcessDuplicator.module
@@ -274,7 +274,7 @@ class ProcessDuplicator extends Process
 		if(count($datas)) {
 			// sort the array by timestamps
 			usort($datas, function($a, $b) {
-				return $a['time'] < $b['time'];
+				return $a['time'] < $b['time'] ? 1 : -1;
 			});
 			// remove the column 'time' before its being rendered
 			array_walk($datas, function (&$value) {


### PR DESCRIPTION
Fixed the following message under PHP 8.0: 
"Deprecated: usort() [function.usort.php]: Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero"

Solution works on later versions than PHP 7 (without spaceship operator):
https://stackoverflow.com/a/65382998