### PR TITLE
Update installer.php

### DIFF
--- a/Deploy/installer.php
+++ b/Deploy/installer.php
@@ -939,7 +939,7 @@ class Installer
     }
 
 
-    $this->ok("Database connection successful to " . htmlspecialchars($values['dbName']));
+    $this->ok("Database connection successful to " . htmlspecialchars($values['dbName'], ENT_QUOTES, 'UTF-8'));
     $options = array(
       'dbCharset' => strtolower($values['dbCharset']),
       'dbEngine' => $values['dbEngine']


### PR DESCRIPTION
Whilst `$values['dbName']` is unlikely to have a quote in it, this adds quote replacement to the `htmlspecialchars()` call to prevent possible issues in `ok()` when it outputs the string.

Found by Psalm's taint analysis.