### PR TITLE
fix: Avoid error when first configuring S3 backups #49

### DIFF
--- a/ProcessDuplicator.module
+++ b/ProcessDuplicator.module
@@ -460,7 +460,7 @@ class ProcessDuplicator extends Process
         $amazonaws->setBucket($this->dupmod->awsBucketName);
         $files = $amazonaws->getFiles();
 
-        if (count($files)) {
+        if ($files && count($files)) {
           foreach ($files as $file) {
             if (strrpos($file['Key'], $extension) == false) continue;
             $originalFilename = $file['Key'];


### PR DESCRIPTION
An exception was triggered on ProcessDuplicator when first configuring S3 backups on an empty bucket.