### PR TITLE
Fix AmazonS3Client namespace issue

### DIFF
--- a/ProcessDuplicator.module
+++ b/ProcessDuplicator.module
@@ -98,7 +98,7 @@ class ProcessDuplicator extends Process
               break;
 
             case 'amazon':
-              $amazonaws = new \AmazonS3Client();
+              $amazonaws = new AmazonS3Client();
               $amazonaws->setAccessKey($this->dupmod->awsAccessKey);
               $amazonaws->setSecretKey($this->dupmod->awsSecretKey);
               $amazonaws->setRegion($this->dupmod->awsRegion);
@@ -143,7 +143,7 @@ class ProcessDuplicator extends Process
               break;
 
             case 'amazon':
-              $amazonaws = new \AmazonS3Client();
+              $amazonaws = new AmazonS3Client();
               $amazonaws->setAccessKey($this->dupmod->awsAccessKey);
               $amazonaws->setSecretKey($this->dupmod->awsSecretKey);
               $amazonaws->setRegion($this->dupmod->awsRegion);


### PR DESCRIPTION
Removed the leading backslash from `\AmazonS3Client()` instantiations in `ProcessDuplicator.module` to correctly instantiate the class from the `ProcessWire` namespace instead of the global namespace. Fixes #55.

---
*PR created automatically by Jules for task [16373201528614247272](https://jules.google.com/task/16373201528614247272) started by @flydev-fr*